### PR TITLE
Introduce a memleak into Jiva for testing the "e2e test case for meml…

### DIFF
--- a/pkg/port/iscsit/iscsid.go
+++ b/pkg/port/iscsit/iscsid.go
@@ -870,9 +870,11 @@ func (s *ISCSITargetDriver) scsiCommandHandler(conn *iscsiConnection) (err error
 		} else {
 			conn.buildRespPackage(OpSCSIResp, task)
 			conn.rxTask = nil
+			/* Introducing the memleak to test the e2e testcase for finding memleaks in Jiva
 			conn.session.PendingTasksMutex.Lock()
 			conn.session.PendingTasks.Delete(task)
 			conn.session.PendingTasksMutex.Unlock()
+			*/
 		}
 	case OpNoopOut:
 		iscsiExecNoopOut(conn)


### PR DESCRIPTION
…eak"

A new e2e test case is being developed to catch the memory leaks introduced as part of PR merge process. This PR deliberately introduces the memleak, and the expected result is - Failure of e2e tests.