### PR TITLE
Reply to initiator with LUN busy when there is a read/write error from backend

### DIFF
--- a/pkg/scsi/backingstore.go
+++ b/pkg/scsi/backingstore.go
@@ -150,7 +150,7 @@ write:
 		if err != nil {
 			log.Error(err)
 			key = MEDIUM_ERROR
-			asc = ASC_READ_ERROR
+			asc = ASC_WRITE_ERROR
 			goto sense
 		}
 		log.Debugf("write data at 0x%x for length %d", offset, len(wbuf))
@@ -169,7 +169,7 @@ write:
 		if ((opcode != api.WRITE_6) && (scb[1]&0x8 != 0)) || (pg.Data[0]&0x04 == 0) {
 			if err = bs.DataSync(); err != nil {
 				key = MEDIUM_ERROR
-				asc = ASC_READ_ERROR
+				asc = ASC_WRITE_ERROR
 				goto sense
 			}
 		}

--- a/pkg/scsi/backingstore/remote.go
+++ b/pkg/scsi/backingstore/remote.go
@@ -75,7 +75,7 @@ func (bs *RemBackingStore) Read(offset, tl int64) ([]byte, error) {
 		return nil, err
 	}
 	if length != len(tmpbuf) {
-		return nil, fmt.Errorf("read is not same length of length")
+		return nil, fmt.Errorf("Incomplete read expected:%d actual:%d", tl, length)
 	}
 	return tmpbuf, nil
 }
@@ -87,7 +87,7 @@ func (bs *RemBackingStore) Write(wbuf []byte, offset int64) error {
 		return err
 	}
 	if length != len(wbuf) {
-		return fmt.Errorf("write is not same length of length")
+		return fmt.Errorf("Incomplete write expected:%d actual:%d", len(wbuf), length)
 	}
 	return nil
 }

--- a/pkg/scsi/sbc.go
+++ b/pkg/scsi/sbc.go
@@ -431,14 +431,16 @@ func SBCReadWrite(host int, cmd *api.SCSICommand) api.SAMStat {
 
 	err, key, asc = bsPerformCommand(dev.Storage, cmd)
 	if err != nil {
-		goto sense
+		fmt.Errorf("Error from backend: %s", err)
+		BuildSenseData(cmd, key, asc)
+		return api.SAMStatBusy
 	} else {
 		return api.SAMStatGood
 	}
 
 sense:
 	BuildSenseData(cmd, key, asc)
-	return api.SAMStatBusy
+	return api.SAMStatCheckCondition
 }
 
 func SBCReserve(host int, cmd *api.SCSICommand) api.SAMStat {

--- a/pkg/scsi/sbc.go
+++ b/pkg/scsi/sbc.go
@@ -438,7 +438,7 @@ func SBCReadWrite(host int, cmd *api.SCSICommand) api.SAMStat {
 
 sense:
 	BuildSenseData(cmd, key, asc)
-	return api.SAMStatCheckCondition
+	return api.SAMStatBusy
 }
 
 func SBCReserve(host int, cmd *api.SCSICommand) api.SAMStat {


### PR DESCRIPTION
If a check condition is returned with medium error, the iscsi initiator marks the volume as read only.
Errors with no space left on disk will be addressed later.
Manual testing was performed by attaching the volume to applications running on kubernetes pods.
After these fixes the Read Only state is avoided if there are network fluctuations or the replica is down for short period of time.
Signed-off-by: Payes <payes.anand@cloudbyte.com>