### PR TITLE
fix(gotgt): use older signature for uuid

### DIFF
--- a/pkg/port/iscsit/session.go
+++ b/pkg/port/iscsit/session.go
@@ -392,8 +392,7 @@ func (s *ISCSITargetDriver) BindISCSISession(conn *iscsiConnection) error {
 			log.Infof("Login request received from initiator: %v, Session type: %s, Target name:%v, ISID: 0x%x",
 				conn.loginParam.initiator, "Normal", conn.loginParam.target, conn.loginParam.isid)
 			//register normal session
-			id, _ := uuid.NewV1()
-			itnexus := &api.ITNexus{id, GeniSCSIITNexusID(newSess)}
+			itnexus := &api.ITNexus{uuid.NewV1(), GeniSCSIITNexusID(newSess)}
 			scsi.AddITNexus(&newSess.Target.SCSITarget, itnexus)
 			newSess.ITNexus = itnexus
 			conn.session = newSess
@@ -415,8 +414,7 @@ func (s *ISCSITargetDriver) BindISCSISession(conn *iscsiConnection) error {
 				return err
 			}
 
-			id, _ := uuid.NewV1()
-			itnexus := &api.ITNexus{id, GeniSCSIITNexusID(newSess)}
+			itnexus := &api.ITNexus{uuid.NewV1(), GeniSCSIITNexusID(newSess)}
 			scsi.AddITNexus(&newSess.Target.SCSITarget, itnexus)
 			newSess.ITNexus = itnexus
 			conn.session = newSess

--- a/pkg/scsi/spc.go
+++ b/pkg/scsi/spc.go
@@ -903,9 +903,8 @@ func SPCPRRegister(host int, cmd *api.SCSICommand) api.SAMStat {
 	} else {
 		if ignoreKey || resKey == 0 {
 			if sAResKey != 0 {
-				id, _ := uuid.NewV1()
 				newRes := &api.SCSIReservation{
-					ID:        id,
+					ID:        uuid.NewV1(),
 					Key:       sAResKey,
 					ITNexusID: cmd.ITNexusID,
 				}


### PR DESCRIPTION
- we are using older release of package "github.com/satori/go.uuid" which
  only returns a single value. Since i'm using the latest release of this
  package locally, which has different signature, i had modified it. This
  commit uses older signature for the compatibility.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>