### PR TITLE
fix(log): rename logrus to log

### DIFF
--- a/pkg/port/iscsit/iscsid.go
+++ b/pkg/port/iscsit/iscsid.go
@@ -280,7 +280,7 @@ func (s *ISCSITargetDriver) Run() error {
 			select {
 			case <-s.done:
 				if iscsiConn != nil {
-					logrus.Warning("Closing connection with initiator...")
+					log.Warning("Closing connection with initiator...")
 					iscsiConn.conn.Close()
 					iscsiConn = nil
 				}


### PR DESCRIPTION
Since we are aliasing logrus as log, build is failing in jiva
Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>